### PR TITLE
Ft add markconfig blog

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,8 +75,6 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
 const nextConfig = {
+  output: 'export',
   swcMinify: false,
   trailingSlash: true,
   env: {

--- a/src/components/MetaTag.js
+++ b/src/components/MetaTag.js
@@ -2,7 +2,6 @@
 //pero no fue posible, por lo este codigo se repite en cada tipo de pantalla (Inicio, lista de post, post)
 import PropTypes from 'prop-types';
 import { META_TAGS } from "../config";
-import { useState, useEffect } from 'react';
 
 MetaTag.propTypes = {
   page: PropTypes.oneOf([

--- a/src/config.js
+++ b/src/config.js
@@ -46,7 +46,7 @@ export const defaultSettings = {
 
 export const HOST_NAME = process.env.HOST_NAME;
 //For meta tags open graph
-const blogDescription = 'Un pequeño blog, en donde se habla de lo que sea';
+export const blogDescription = 'Un pequeño blog, en donde se habla de lo que sea';
 const blogTitle = 'Blog';
 const homeTitle = 'Markconfig - Desarrollador de software, Java, Spring Boot, React, NextJs, Javascript, MySQL, Arduino';
 const homeDescription = 'Sitio web, portafolio, contacto y blog de Markconfig';

--- a/src/pages/blog/[slug]/index.js
+++ b/src/pages/blog/[slug]/index.js
@@ -25,7 +25,7 @@ import {
   // BlogPostCommentForm,
 } from '../../../sections/blog';
 
-import { HOST_NAME, blogDescription, META_TAGS } from '../../../config';
+import { blogDescription, META_TAGS } from '../../../config';
 // ----------------------------------------------------------------------
 
 const RootStyle = styled('div')(({ theme }) => ({

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -18,7 +18,7 @@ import HeaderBreadcrumbs from '../../components/HeaderBreadcrumbs';
 import { BlogPostCard, BlogPostsSort, /*BlogPostsSearch*/ } from '../../sections/blog';
 //api blogs
 import { getAllPosts } from '../../utils/lib/api';
-import { HOST_NAME, blogDescription, blogTitle, META_TAGS } from '../../config';
+import { META_TAGS } from '../../config';
 // ----------------------------------------------------------------------
 
 const RootStyle = styled('div')(({ theme }) => ({


### PR DESCRIPTION
fix errors about:  The "next export" command has been removed in favor of "output: export" in next.config.js. Learn more: https://nextjs.org/docs/advanced-features/static-html-export